### PR TITLE
Configure local Gradle build cache and always publish Build Scan

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,5 @@
 name: Build GOTY Server
-on: 
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
+on: [ push, workflow_dispatch ]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # game-of-the-year
+
+By developing this project you implicitly agree to the Gradle Terms of Use at https://gradle.com/terms-of-service.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 # game-of-the-year
-
-By developing this project you implicitly agree to the Gradle Terms of Use at https://gradle.com/terms-of-service.

--- a/goty-server/build.gradle.kts
+++ b/goty-server/build.gradle.kts
@@ -19,12 +19,11 @@ kotlin {
 
 repositories {
     mavenCentral()
-    maven("https://jitpack.io")
 }
 
 dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
-    implementation("com.github.husnjak:IGDB-API-JVM:1.0.5")
+    implementation("io.github.husnjak:igdb-api-jvm:1.0.7")
     implementation("com.google.guava:guava:31.1-jre")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/goty-server/build.gradle.kts
+++ b/goty-server/build.gradle.kts
@@ -23,8 +23,8 @@ repositories {
 
 dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
-    implementation("io.github.husnjak:igdb-api-jvm:1.0.7")
     implementation("com.google.guava:guava:31.1-jre")
+    implementation("io.github.husnjak:igdb-api-jvm:1.0.7")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")

--- a/goty-server/gradle.properties
+++ b/goty-server/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/goty-server/gradle/wrapper/gradle-wrapper.properties
+++ b/goty-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-milestone-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/goty-server/gradle/wrapper/gradle-wrapper.properties
+++ b/goty-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-milestone-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/goty-server/settings.gradle.kts
+++ b/goty-server/settings.gradle.kts
@@ -1,1 +1,16 @@
+plugins {
+    id("com.gradle.enterprise") version "3.11.1"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8.1"
+}
+
 rootProject.name = "goty-server"
+
+gradleEnterprise {
+    buildScan {
+        publishAlways()
+
+        // By developing this project you implicitly agree to the Gradle Terms of Use.
+        termsOfServiceAgree = "yes"
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+    }
+}

--- a/goty-server/settings.gradle.kts
+++ b/goty-server/settings.gradle.kts
@@ -1,16 +1,1 @@
-plugins {
-    id("com.gradle.enterprise") version "3.11.1"
-    id("com.gradle.common-custom-user-data-gradle-plugin") version "1.8.1"
-}
-
 rootProject.name = "goty-server"
-
-gradleEnterprise {
-    buildScan {
-        publishAlways()
-
-        // By developing this project you implicitly agree to the Gradle Terms of Use.
-        termsOfServiceAgree = "yes"
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    }
-}


### PR DESCRIPTION
What changed?

- Local builds leverage Gradle Build Caching.
- The `igdb-api-jvm` dependency from JitPack seemed to be causing build problems so I replaced it with the one from Maven Central.