### PR TITLE
add basic endpoint security, secure put properties

### DIFF
--- a/goty-server/build.gradle.kts
+++ b/goty-server/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0") {
         because("kotlin any() support")
@@ -38,6 +39,7 @@ dependencies {
     testImplementation("org.mockito:mockito-inline:2.8.47") {
         because("mocking final classes (ex: IGDBWrapper)")
     }
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.withType<Test>().configureEach {

--- a/goty-server/src/main/kotlin/com/aleinin/goty/configuration/AdminCredentials.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/configuration/AdminCredentials.kt
@@ -1,0 +1,15 @@
+package com.aleinin.goty.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+import javax.validation.constraints.NotEmpty
+
+@ConfigurationProperties("goty.admin")
+@Validated
+data class AdminCredentials(
+    @field:NotEmpty
+    var username: String? = null,
+
+    @field:NotEmpty
+    var password: String? = null
+)

--- a/goty-server/src/main/kotlin/com/aleinin/goty/configuration/AuthenticationConfiguration.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/configuration/AuthenticationConfiguration.kt
@@ -1,0 +1,24 @@
+package com.aleinin.goty.configuration
+
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Service
+import org.springframework.validation.annotation.Validated
+
+
+@Service
+class AuthenticationConfiguration(@Validated private val adminCredentials: AdminCredentials): AuthenticationManager {
+    override fun authenticate(authentication: Authentication?): Authentication {
+        val username: String? = authentication?.name
+        val password: String = authentication?.credentials.toString()
+        val grantedAuths: MutableList<GrantedAuthority> = ArrayList()
+        if (username == adminCredentials.username && password == adminCredentials.password) {
+            grantedAuths.add(SimpleGrantedAuthority("ROLE_ADMIN"))
+        }
+        return UsernamePasswordAuthenticationToken(username, password, grantedAuths)
+    }
+
+}

--- a/goty-server/src/main/kotlin/com/aleinin/goty/configuration/SecurityConfiguration.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/configuration/SecurityConfiguration.kt
@@ -1,0 +1,22 @@
+package com.aleinin.goty.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableMethodSecurity
+class SecurityConfiguration {
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf()
+                .disable()
+            .authorizeHttpRequests()
+                .anyRequest().permitAll().and()
+            .httpBasic()
+        return http.build()
+    }
+}

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesController.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesController.kt
@@ -1,5 +1,6 @@
 package com.aleinin.goty.properties
 
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -17,5 +18,6 @@ class PropertiesController(
     fun getProperties() = propertiesService.getProperties()
 
     @PutMapping("/properties")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     fun putProperties(@RequestBody request: Properties) = propertiesService.replaceProperties(request)
 }

--- a/goty-server/src/test/kotlin/com/aleinin/goty/configuration/AuthenticationConfigurationTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/configuration/AuthenticationConfigurationTest.kt
@@ -1,0 +1,52 @@
+package com.aleinin.goty.configuration
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+@ExtendWith(MockitoExtension::class)
+internal class AuthenticationConfigurationTest {
+    @Mock
+    lateinit var adminCredentials: AdminCredentials
+
+    @Mock
+    lateinit var authentication: Authentication
+
+    @InjectMocks
+    lateinit var authenticationConfiguration: AuthenticationConfiguration
+
+    val adminAuthority = SimpleGrantedAuthority("ROLE_ADMIN")
+
+    val adminUsername = "adminUsername"
+    val adminPassword = "adminPassword"
+
+    @BeforeEach
+    fun setup() {
+        whenever(adminCredentials.username).thenReturn(adminUsername)
+        whenever(adminCredentials.password).thenReturn(adminPassword)
+    }
+
+    @Test
+    fun `Should add ROLE_ADMIN if the admin credentials are provided`() {
+        whenever(authentication.name).thenReturn(adminUsername)
+        whenever(authentication.credentials).thenReturn(adminPassword)
+        val actualAuthorities = authenticationConfiguration.authenticate(authentication).authorities
+        assertTrue(actualAuthorities.contains(adminAuthority))
+    }
+
+    @Test
+    fun `Should not add ROLE_ADMIN if incorrect credentials are provided`() {
+        whenever(authentication.name).thenReturn(adminUsername)
+        whenever(authentication.credentials).thenReturn("incorrect")
+        val actualAuthorities = authenticationConfiguration.authenticate(authentication).authorities
+        assertFalse(actualAuthorities.contains(adminAuthority))
+    }
+}

--- a/goty-server/src/test/resources/application.yml
+++ b/goty-server/src/test/resources/application.yml
@@ -1,4 +1,7 @@
 goty:
+  admin:
+    username: test
+    password: test
   default:
     gotyYear: 2077
     deadline: 2077-01-01T00:00:00-05:00


### PR DESCRIPTION
## What Changed?
* Added spring-security
* By default, all endpoints are unsecured
* Some endpoints require role "ADMIN". ADMIN role is assigned if credentials are provided that match the goty.admin.username and goty.admin.password (by default assigned by env variable)
* PUT /properties/ secured
* Updated tests accordingly 

closes #47 