### PR TITLE
bug fixes

### DIFF
--- a/goty-client/src/api/propertiesService.ts
+++ b/goty-client/src/api/propertiesService.ts
@@ -10,7 +10,7 @@ export interface BackendProperties {
   giveawayAmountUSD: number
 }
 
-const toBackendPropertiesToProperties = ({
+const toProperties = ({
   tiePoints,
   gotyYear,
   deadline,
@@ -23,14 +23,12 @@ const toBackendPropertiesToProperties = ({
   hasGiveaway,
   giveawayAmountUSD,
   maxGamesOfTheYear: tiePoints.length,
-  isGotyConcluded: false, // todo
+  isGotyConcluded: new Date(deadline) <= new Date(),
 })
 
 export const propertiesService = {
-  getProperties: (): Promise<Properties> => {
-    return axios.get<BackendProperties>('/properties').then((axiosResponse) => {
-      console.log(axiosResponse.data)
-      return toBackendPropertiesToProperties(axiosResponse.data)
-    })
-  },
+  getProperties: (): Promise<Properties> =>
+    axios
+      .get<BackendProperties>('/properties')
+      .then((axiosResponse) => toProperties(axiosResponse.data)),
 }

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/Properties.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/Properties.kt
@@ -13,6 +13,5 @@ data class Properties(
         require(tiePoints.isNotEmpty()) { "tiePoints must not be empty" }
         require(tiePoints.sortedDescending() == tiePoints) { "tiePoints must be in descending order"}
         require(giveawayAmountUSD >= 0) { "giveawayAmountUSD must be greater than or equal to 0" }
-        require(ZonedDateTime.now().isBefore(deadline)) { "deadline cannot be in the past" }
     }
 }

--- a/goty-server/src/test/kotlin/com/aleinin/goty/game/GameSearchServiceTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/game/GameSearchServiceTest.kt
@@ -22,7 +22,7 @@ internal class GameSearchServiceTest {
             title = "MyGame",
             limit = 10,
             year = 2077,
-            mainGame = true
+            mainGame = false
         )
         val expectedResponse = listOf(
             GameSearchResponse(

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesRepositoryTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesRepositoryTest.kt
@@ -40,7 +40,7 @@ internal class PropertiesRepositoryTest {
         whenever(propertiesDocumentRepository.findById(propertiesId)).thenReturn(Optional.of(mockDocument))
         val expected = Optional.of(
             Properties(
-                gotyYear = thisYear(),
+                gotyYear = deadline.year,
                 tiePoints = listOf(3, 2, 1),
                 deadline = deadline,
                 hasGiveaway = true,


### PR DESCRIPTION
Miscellaneous bug fixes

## What changed?
* isGotyConcluded implemented, previously was erroneously left as hardcoded false
* Removed leftover console.log
* removed requirement that datetime cannot be in the past. Why? Because this causes an exception to be thrown when the deadline is past. Obvious in hindsight, but originally the goal was to prevent someone from setting an improper deadline. But of course this causes the instantiation of Properties to break once the deadline passes. This functionality should be implemented in the PUT validation, if done at all.
* changed mainGame default value to false instead of true. The game enum needs further work. The goal was to prevent bad results from appearing but it was too strict and caused proper results not to appear (For example, Dwarf Fortress which is listed as a "Remaster").
* Changed a testcase that was incorrectly passing due to the year (discovered due to new year)