### PR TITLE
String templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ curl --location --request PUT 'http://localhost:8080/properties?localTimeZone=Am
 --header 'Authorization: Basic PASSWORD' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "title": "The Midnight Watchmen'\''s\nTop Games of the Year ${year}",
+    "title": "My Top Games of the Year ${year}",
     "year": 2023,
     "gotyQuestion": {
         "title": "Games of the Year",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The app was built to be easily customizable and reusable year-to-year while stil
   - View summary of submissions
 - Home Page
   - Allows submission, editing, or viewing of results depending on contest status and user's submission status
-
+- Properties
+  - Allows configuration of various aspects of the vote including variable support for text
 ## Tech Stack
 
 - Frontend:
@@ -51,12 +52,31 @@ game-of-the-year's depends on a few different configurables. The majority of thi
 
 An example request:
 
+Text properties support the following variables in `${VARIABLE_NAME}` format
+
+| Variable | Resolves to                                                                                                                   | Additional Info                                                                                                      |
+|----------|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| year     | properties.year                                                                                                               |                                                                                                                      |
+| deadline | properties.deadline in "MM:DD:YYYY hh:MM AM/PM" format according to localTimeZone, or properties.defaultLocalTimeZone, or UTC | localTimeZone is supplied as a queryParam to the PropertiesController. ex: /properties?localTimeZone=America/Chicago |
+| maxGames | properties.tiePoints.size                                                                                                     |                                                                                                                      |
+
 ```bash
-curl --location --request PUT 'http://localhost:8080/properties' \
+curl --location --request PUT 'http://localhost:8080/properties?localTimeZone=America/Chicago' \
+--header 'Authorization: Basic PASSWORD' \
 --header 'Content-Type: application/json' \
 --data-raw '{
+    "title": "The Midnight Watchmen'\''s\nTop Games of the Year ${year}",
+    "year": 2023,
+    "gotyQuestion": {
+        "title": "Games of the Year",
+        "question": "What are your favorite game(s) of ${year}?",
+        "rules": [
+            "Voting closes ${deadline}.",
+            "May nominate any amount of games up to ${maxGames}."
+        ]
+    },
     "tiePoints": [
-        14,
+        15,
         13,
         11,
         7,
@@ -67,9 +87,10 @@ curl --location --request PUT 'http://localhost:8080/properties' \
         2,
         1
     ],
-    "deadline": "2023-01-01T00:00:00-05:00",
+    "deadline": "2024-01-01T00:00:00-05:00",
     "hasGiveaway": true,
-    "giveawayAmountUSD": 25
+    "giveawayAmountUSD": 25,
+    "defaultLocalTimeZone": "America/New_York"
 }'
 ```
 
@@ -108,6 +129,13 @@ The following environmental variables need to be set with an IGDB clientId and c
 - GOTY_IGDB_TWITCH_CLIENT_SECRET
 
 If you don't have IGDB API credentials check out [Account Creation](https://api-docs.igdb.com/#about) on IGDB's docs page
+
+The following environmental variables need to be set with admin credentials for protected endpoints
+
+- GOTY_ADMIN_USERNAME
+- GOTY_ADMIN_PASSWORD
+
+Credentials are provided with basic auth to protected endpoints
 
 #### Mongo
 

--- a/adrs/ADR-5-template-strings.md
+++ b/adrs/ADR-5-template-strings.md
@@ -4,7 +4,7 @@
 
 Text in the frontend is currently hardcoded, which requires code changes for small changes to questions
 
-This also limits the usefulness to other people in the (rare) chacne someone else wanted to use this app
+This also limits the usefulness to other people in the (rare) chance someone else wanted to use this app
 
 ## Decision
 
@@ -25,7 +25,7 @@ One challenge is showing the users the deadline in their local time. Whenever a 
 
 For example, GET /properties?localTimeZone=America/Chicago would return the formatted date in Chicago time (CST or CDT)
 
-If no localTimeZone is provided, the user can also provide a defaultLocalTimeZone in their `Properties` that will be used instead
+If no localTimeZone is provided, the admin can also provide a defaultLocalTimeZone in their `Properties` that will be used instead
 
 if no localTimeZone and no defaultLocalTimeZone exist, then UTC will be used.
 

--- a/adrs/ADR-5-template-strings.md
+++ b/adrs/ADR-5-template-strings.md
@@ -1,0 +1,50 @@
+## Date: 11/25/2023
+
+## Problem
+
+Text in the frontend is currently hardcoded, which requires code changes for small changes to questions
+
+This also limits the usefulness to other people in the (rare) chacne someone else wanted to use this app
+
+## Decision
+
+The web page title, goty question title, goty question, and goty rules will be moved to the backend via `Properties`
+
+In order to support variables in the strings there will be a small templating system like shown:
+
+template: "It is ${year}"
+
+which, given properties.year was `2023`, would translate to:
+
+text: "It is 2023"
+
+## Time zones
+One challenge is showing the users the deadline in their local time. Whenever a user calls GET /properties/ they can pass in a queryParam `localTimeZone`
+
+`localTimeZone` is a `zoneId` corresponding to a [tz identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+
+For example, GET /properties?localTimeZone=America/Chicago would return the formatted date in Chicago time (CST or CDT)
+
+If no localTimeZone is provided, the user can also provide a defaultLocalTimeZone in their `Properties` that will be used instead
+
+if no localTimeZone and no defaultLocalTimeZone exist, then UTC will be used.
+
+## ResolvedTemplate
+After translation, text is stored in a `ResolvedTemplate` object which contains the original template string `template` and the translated text `text`
+
+example:
+```json
+{
+  "template": "It is ${year}",
+  "text": "It is 2023"
+}
+```
+
+Resolved templates will be part of a `PropertiesResponse` which is returned when either GETing or PUTing the properties
+
+## Limitations
+* Only a small amount of tokens will be supported at first
+  * ${year} -> properties.year
+  * ${maxGames} -> properties.tiePoints.size
+  * ${deadline} -> properties.deadline in "MM:DD:YYYY hh:MM AM/PM" format according to localTimeZone, or defaultLocalTimeZone, or UTC
+* No escape support for now (although i'm not sure why you'd need to write ${year} as plaintext)

--- a/adrs/ADR-5-template-strings.md
+++ b/adrs/ADR-5-template-strings.md
@@ -10,7 +10,7 @@ This also limits the usefulness to other people in the (rare) chance someone els
 
 The web page title, goty question title, goty question, and goty rules will be moved to the backend via `Properties`
 
-In order to support variables in the strings there will be a small templating system like shown:
+In order to support variables in the strings Apache Commons [StringSubstitutor](https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/StringSubstitutor.html) will be used
 
 template: "It is ${year}"
 
@@ -47,4 +47,3 @@ Resolved templates will be part of a `PropertiesResponse` which is returned when
   * ${year} -> properties.year
   * ${maxGames} -> properties.tiePoints.size
   * ${deadline} -> properties.deadline in "MM:DD:YYYY hh:MM AM/PM" format according to localTimeZone, or defaultLocalTimeZone, or UTC
-* No escape support for now (although i'm not sure why you'd need to write ${year} as plaintext)

--- a/goty-client/src/api/backendModels/backendProperties.ts
+++ b/goty-client/src/api/backendModels/backendProperties.ts
@@ -1,26 +1,44 @@
 import { Properties } from '../../models/properties'
 import { dateStringToTwelveHourString } from '../../util/time'
 
+interface ResolvedTemplate {
+  template: string
+  text: string
+}
+
 export interface BackendProperties {
+  title: ResolvedTemplate
+  year: number
+  goty: {
+    title: ResolvedTemplate
+    question: ResolvedTemplate
+    rules: ResolvedTemplate[]
+  }
   tiePoints: number[]
-  gotyYear: number
   deadline: string
   hasGiveaway: boolean
   giveawayAmountUSD: number
+  defaultLocalTimeZone: string
 }
 
 export const fromBackendPropertiesToProperties = ({
+  title,
+  goty,
   tiePoints,
-  gotyYear,
+  year,
   deadline,
   hasGiveaway,
   giveawayAmountUSD,
 }: BackendProperties): Properties => ({
+  title: title.text,
+  goty: {
+    title: goty.title.text,
+    question: goty.question.text,
+    rules: goty.rules.map((rule) => rule.text),
+  },
   tiePoints,
-  year: gotyYear,
+  year,
   deadline: dateStringToTwelveHourString(deadline),
   hasGiveaway,
   giveawayAmountUSD,
-  maxGamesOfTheYear: tiePoints.length,
-  isGotyConcluded: new Date(deadline) <= new Date(),
 })

--- a/goty-client/src/api/backendModels/backendProperties.ts
+++ b/goty-client/src/api/backendModels/backendProperties.ts
@@ -9,7 +9,7 @@ interface ResolvedTemplate {
 export interface BackendProperties {
   title: ResolvedTemplate
   year: number
-  goty: {
+  gotyQuestion: {
     title: ResolvedTemplate
     question: ResolvedTemplate
     rules: ResolvedTemplate[]
@@ -23,7 +23,7 @@ export interface BackendProperties {
 
 export const fromBackendPropertiesToProperties = ({
   title,
-  goty,
+  gotyQuestion,
   tiePoints,
   year,
   deadline,
@@ -31,10 +31,10 @@ export const fromBackendPropertiesToProperties = ({
   giveawayAmountUSD,
 }: BackendProperties): Properties => ({
   title: title.text,
-  goty: {
-    title: goty.title.text,
-    question: goty.question.text,
-    rules: goty.rules.map((rule) => rule.text),
+  gotyQuestion: {
+    title: gotyQuestion.title.text,
+    question: gotyQuestion.question.text,
+    rules: gotyQuestion.rules.map((rule) => rule.text),
   },
   tiePoints,
   year,

--- a/goty-client/src/api/propertiesService.ts
+++ b/goty-client/src/api/propertiesService.ts
@@ -8,6 +8,10 @@ import {
 export const propertiesService = {
   getProperties: (): Promise<Properties> =>
     fetcher
-      .get<BackendProperties>('/properties')
+      .get<BackendProperties>(
+        `/properties?localTimeZone=${
+          Intl.DateTimeFormat().resolvedOptions().timeZone
+        }`,
+      )
       .then(fromBackendPropertiesToProperties),
 }

--- a/goty-client/src/components/Header.tsx
+++ b/goty-client/src/components/Header.tsx
@@ -5,11 +5,10 @@ import { Card } from './controls/Card/Card'
 import styles from './Header.module.scss'
 
 export const Header = () => {
-  const { year } = useSelector(selectProperties)
+  const { title } = useSelector(selectProperties)
   return (
     <Card className={styles.main}>
-      <h1 className={styles.title}>The Midnight Watchmen's</h1>
-      <h1 className={styles.title}>Top Games of the Year {year}</h1>
+      <h1 className={styles.title}>{title}</h1>
     </Card>
   )
 }

--- a/goty-client/src/components/controls/Card/Card.module.scss
+++ b/goty-client/src/components/controls/Card/Card.module.scss
@@ -21,6 +21,7 @@
 .header {
   display: flex;
   justify-content: space-between;
+  margin-bottom: 15px;
 }
 
 .title {

--- a/goty-client/src/components/controls/Card/Card.tsx
+++ b/goty-client/src/components/controls/Card/Card.tsx
@@ -6,7 +6,7 @@ export interface CardProps {
   title?: string
   titleFontSize?: string
   required?: boolean
-  subtitle?: string
+  index?: string
   border?: boolean
   className?: string
   style?: CSSProperties
@@ -16,18 +16,18 @@ export const Card = (props: React.PropsWithChildren<CardProps>) => {
   const title = (
     <span
       className={styles.title}
-      style={{ fontSize: `${props.titleFontSize ?? '20px'}` }}
+      style={{ fontSize: `${props.titleFontSize ?? '1.5em'}` }}
     >
       {props.title}{' '}
       {props.required ? <span className={styles.required}>*</span> : null}
     </span>
   )
-  const subtitle = props.subtitle ? <span>{props.subtitle}</span> : null
+  const index = props.index ? <span>{props.index}</span> : null
   const header =
-    props.title || props.required || props.subtitle ? (
+    props.title || props.required || props.index ? (
       <div className={styles.header}>
         {title}
-        {subtitle}
+        {index}
       </div>
     ) : null
   return (

--- a/goty-client/src/components/results/ExportButton/createExportData.ts
+++ b/goty-client/src/components/results/ExportButton/createExportData.ts
@@ -131,7 +131,7 @@ export const createExportData = (
   createSubmissionsSection(
     'Submissions',
     submissions,
-    properties.maxGamesOfTheYear,
+    properties.tiePoints.length,
   ),
   createPropertiesSection('Properties', properties),
   createTextSection('Tie points', properties.tiePoints),

--- a/goty-client/src/components/results/ResultsPage.tsx
+++ b/goty-client/src/components/results/ResultsPage.tsx
@@ -37,7 +37,7 @@ export const ResultsPage = () => {
   const { pathname } = useLocation()
   const activeTab = getActiveTab(pathname)
   useEffect(() => {
-    document.title = `TMW GOTY - ${activeTab}`
+    document.title = `GOTY - ${activeTab}`
   }, [activeTab])
   const handleTabChange = (tab: string) => navigate(`${tab}`)
 

--- a/goty-client/src/components/results/ResultsTable/ResultsTable.tsx
+++ b/goty-client/src/components/results/ResultsTable/ResultsTable.tsx
@@ -14,7 +14,7 @@ export interface ResultsTableProps<T> {
 export const ResultsTable = <T,>(props: ResultsTableProps<T>) => (
   <Card
     title={props.title}
-    subtitle={`${props.rows.length} row${props.rows.length !== 1 ? 's' : ''}`}
+    index={`${props.rows.length} row${props.rows.length !== 1 ? 's' : ''}`}
   >
     <div className={styles.marginTop5}>
       <Table

--- a/goty-client/src/components/submission/End/End.tsx
+++ b/goty-client/src/components/submission/End/End.tsx
@@ -15,7 +15,7 @@ export const End = () => {
     store.dispatch(createNextStepAction())
   }
   useEffect(() => {
-    document.title = 'TMW GOTY - End'
+    document.title = 'GOTY - End'
   }, [])
   return (
     <Card>

--- a/goty-client/src/components/submission/Form/Form.tsx
+++ b/goty-client/src/components/submission/Form/Form.tsx
@@ -33,7 +33,7 @@ export const Form = () => {
       })
   }
   useEffect(() => {
-    document.title = 'TMW GOTY - Submission'
+    document.title = 'GOTY - Submission'
   }, [])
   return (
     <>

--- a/goty-client/src/components/submission/GOTY.tsx
+++ b/goty-client/src/components/submission/GOTY.tsx
@@ -85,9 +85,9 @@ export const GOTY = (props: GOTYProps) => {
     }
   }
   return (
-    <Card title={properties.goty.title} required={true}>
-      <span>{properties.goty.question}</span>
-      <Rules readonly={props.readonly} rules={properties.goty.rules} />
+    <Card title={properties.gotyQuestion.title} required={true}>
+      <span>{properties.gotyQuestion.question}</span>
+      <Rules readonly={props.readonly} rules={properties.gotyQuestion.rules} />
       {!props.readonly && getTieBreaker(properties.tiePoints)}
       {props.readonly ||
       props.games.length === properties.tiePoints.length ? null : (

--- a/goty-client/src/components/submission/GOTY.tsx
+++ b/goty-client/src/components/submission/GOTY.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { useSelector, useStore } from 'react-redux'
 import { selectProperties } from '../../state/properties/selectors'
 import { createUpdateGamesOfTheYearAction } from '../../state/submission/actions'
-import { generateRules } from '../../util/generate-rules'
 import { indexToOrdinal } from '../../util/index-to-ordinal'
 import { Card } from '../controls/Card/Card'
 import { OrderableList } from './shared/OrderableList'
 import { Search } from './shared/Search'
 import { Game } from '../../models/game'
+import { Rules } from './Rules'
 
 export interface GOTYProps {
   games: Game[]
@@ -18,17 +18,6 @@ export enum MoveDirection {
   IncreaseRank,
   DecreaseRank,
 }
-
-const getRules = (closeDate: string, year: number) => [
-  <li key="gotyClose">Voting closes {closeDate}</li>,
-  'You may nominate as many games as you want up to a total of 10. Only the GOTY is required, but I encourage you all to answer the bonus questions!',
-  <li key="gotyYear">
-    Eligible games must have been released in {year}. Early Access games are
-    fine as long as they were released in {year}.{' '}
-  </li>,
-  'DLC is not eligible',
-  'Games will be rated based on number of votes. In the event of a tie points will be awarded based off the ranking in your list. ',
-]
 
 const getTieBreaker = (tiePoints: number[]) => {
   return (
@@ -74,10 +63,7 @@ export const GOTY = (props: GOTYProps) => {
   const setGames = (games: Game[]) =>
     store.dispatch(createUpdateGamesOfTheYearAction(games))
   const handleAddGame = (gameToAdd: Game) => {
-    if (
-      !props.readonly &&
-      props.games.length !== properties.maxGamesOfTheYear
-    ) {
+    if (!props.readonly && props.games.length !== properties.tiePoints.length) {
       setGames([
         ...props.games.filter((game) => game.id !== gameToAdd.id),
         gameToAdd,
@@ -99,17 +85,12 @@ export const GOTY = (props: GOTYProps) => {
     }
   }
   return (
-    <Card
-      title={`What are your favorite game(s) of ${properties.year}?`}
-      required={true}
-    >
-      {generateRules(
-        props.readonly,
-        getRules(properties.deadline, properties.year),
-      )}
+    <Card title={properties.goty.title} required={true}>
+      <span>{properties.goty.question}</span>
+      <Rules readonly={props.readonly} rules={properties.goty.rules} />
       {!props.readonly && getTieBreaker(properties.tiePoints)}
       {props.readonly ||
-      props.games.length === properties.maxGamesOfTheYear ? null : (
+      props.games.length === properties.tiePoints.length ? null : (
         <Search
           year={properties.year}
           placeholder="Select a game"

--- a/goty-client/src/components/submission/Giveaway.tsx
+++ b/goty-client/src/components/submission/Giveaway.tsx
@@ -44,10 +44,8 @@ export const Giveaway = (props: GiveawayProps) => {
     },
   ]
   return (
-    <Card
-      title={`Do you want to enter the $${giveawayAmountUSD} Steam GC Giveaway?`}
-      required={true}
-    >
+    <Card title={'Giveaway'} required={true}>
+      <span>{`Do you want to enter the $${giveawayAmountUSD} Steam GC Giveaway?`}</span>
       {generateRules(props.readonly, rules(deadline))}
       <RadioSet
         disabled={props.readonly}

--- a/goty-client/src/components/submission/MostAnticipated.tsx
+++ b/goty-client/src/components/submission/MostAnticipated.tsx
@@ -21,7 +21,8 @@ export const MostAnticipated = (props: MostAnticipatedProps) => {
   }
   return (
     <SingleGame
-      title="What game are you looking forward to most?"
+      title="Most Anticipated"
+      subtitle="What game are you looking forward to most?"
       readonly={props.readonly}
       game={props.mostAnticipated}
       handleSelect={handleSelect}

--- a/goty-client/src/components/submission/OldGame.tsx
+++ b/goty-client/src/components/submission/OldGame.tsx
@@ -22,7 +22,8 @@ export const OldGame = (props: OldGameProps) => {
   }
   return (
     <SingleGame
-      title={`What is your favorite OLD game of ${year}`}
+      title="Best Old Game"
+      subtitle={`What is your favorite old game of ${year}?`}
       readonly={props.readonly}
       game={props.bestOldGame}
       handleSelect={handleSelect}

--- a/goty-client/src/components/submission/Rules.tsx
+++ b/goty-client/src/components/submission/Rules.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface RulesProps {
+  readonly: boolean
+  rules: string[]
+}
+
+export const Rules = ({ readonly, rules }: RulesProps) => {
+  if (readonly) {
+    return null
+  }
+  return (
+    <>
+      <p>Rules:</p>
+      <ul>
+        {rules.map((rule, index) => (
+          <li key={index}>{rule}</li>
+        ))}
+      </ul>
+    </>
+  )
+}

--- a/goty-client/src/components/submission/Start/Start.tsx
+++ b/goty-client/src/components/submission/Start/Start.tsx
@@ -8,6 +8,7 @@ import { selectProperties } from '../../../state/properties/selectors'
 import { Button } from '../../controls/Button/Button'
 import styles from './Start.module.scss'
 import { Summary } from '../../results/Summary/Summary'
+import { isGotyConcluded } from '../../../util/isGotyConcluded'
 
 export interface StartProps {
   isLoading: boolean
@@ -61,15 +62,15 @@ export const Start = (props: StartProps) => {
   const properties = useSelector(selectProperties)
   const hasSubmission: boolean = useSelector(selectIsEdit)
   useEffect(() => {
-    document.title = 'TMW GOTY - Start'
-    if (properties.isGotyConcluded) {
+    document.title = 'GOTY - Start'
+    if (isGotyConcluded(properties.deadline)) {
       loadResults(store)
     }
   }, [properties, store])
   const handleClick = () => {
     store.dispatch(createNextStepAction())
   }
-  if (properties.isGotyConcluded) {
+  if (isGotyConcluded(properties.deadline)) {
     return <Concluded year={properties.year} />
   }
   return (

--- a/goty-client/src/components/submission/shared/SingleGame.tsx
+++ b/goty-client/src/components/submission/shared/SingleGame.tsx
@@ -5,6 +5,7 @@ import { Game } from '../../../models/game'
 
 export interface SingleGameProps {
   title: string
+  subtitle?: string
   content: JSX.Element | null
   readonly: boolean
   game: Game | null
@@ -14,6 +15,7 @@ export interface SingleGameProps {
 export const SingleGame = (props: SingleGameProps) => {
   return (
     <Card title={props.title}>
+      {props.subtitle && <span>{props.subtitle}</span>}
       {props.content}
       <SearchInPlace
         readonly={props.readonly}

--- a/goty-client/src/models/properties.ts
+++ b/goty-client/src/models/properties.ts
@@ -1,6 +1,6 @@
 export interface Properties {
   title: string
-  goty: {
+  gotyQuestion: {
     title: string
     question: string
     rules: string[]

--- a/goty-client/src/models/properties.ts
+++ b/goty-client/src/models/properties.ts
@@ -1,9 +1,13 @@
 export interface Properties {
+  title: string
+  goty: {
+    title: string
+    question: string
+    rules: string[]
+  }
   tiePoints: number[]
   year: number
   deadline: string
   hasGiveaway: boolean
   giveawayAmountUSD: number
-  maxGamesOfTheYear: number
-  isGotyConcluded: boolean
 }

--- a/goty-client/src/state/properties/reducer.ts
+++ b/goty-client/src/state/properties/reducer.ts
@@ -4,7 +4,7 @@ import { Properties } from '../../models/properties'
 const currentYear = () => new Date().getFullYear()
 
 const initialState: Properties = {
-  goty: { question: '', rules: [''], title: '' },
+  gotyQuestion: { question: '', rules: [''], title: '' },
   title: '',
   tiePoints: [],
   year: currentYear(),

--- a/goty-client/src/state/properties/reducer.ts
+++ b/goty-client/src/state/properties/reducer.ts
@@ -4,18 +4,18 @@ import { Properties } from '../../models/properties'
 const currentYear = () => new Date().getFullYear()
 
 const initialState: Properties = {
+  goty: { question: '', rules: [''], title: '' },
+  title: '',
   tiePoints: [],
   year: currentYear(),
   deadline: `1/1/${currentYear() + 1}`,
   hasGiveaway: true,
   giveawayAmountUSD: 0,
-  maxGamesOfTheYear: 0,
-  isGotyConcluded: false,
 }
 
 export const propertiesReducer = (
   state = initialState,
-  action: PropertiesActions
+  action: PropertiesActions,
 ) => {
   switch (action.type) {
     case SET_PROPERTIES:

--- a/goty-client/src/util/isGotyConcluded.ts
+++ b/goty-client/src/util/isGotyConcluded.ts
@@ -1,0 +1,2 @@
+export const isGotyConcluded = (deadline: string) =>
+  new Date(deadline) <= new Date()

--- a/goty-server/build.gradle.kts
+++ b/goty-server/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.apache.commons:commons-text:1.11.0")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0") {

--- a/goty-server/src/main/kotlin/com/aleinin/goty/configuration/DefaultProperties.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/configuration/DefaultProperties.kt
@@ -1,5 +1,6 @@
 package com.aleinin.goty.configuration
 
+import com.aleinin.goty.properties.GotyQuestion
 import com.aleinin.goty.properties.Properties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.format.annotation.DateTimeFormat
@@ -7,25 +8,38 @@ import org.springframework.validation.annotation.Validated
 import java.time.ZonedDateTime
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.PositiveOrZero
+import java.time.ZoneId
 
 fun DefaultProperties.toProperties() = Properties(
-    gotyYear = this.gotyYear,
+    title = this.title,
+    goty = this.goty,
+    year = this.year,
     tiePoints = this.tiePoints,
     deadline = this.deadline,
     hasGiveaway = this.hasGiveaway,
-    giveawayAmountUSD = this.giveawayAmountUSD
+    giveawayAmountUSD = this.giveawayAmountUSD,
+    defaultLocalTimeZone = this.defaultLocalTimeZone,
 )
-
 
 @ConfigurationProperties("goty.default")
 @Validated
 data class DefaultProperties(
     @field:NotNull
-    val gotyYear: Int,
+    val title: String,
+
+    @field:NotNull
+    val goty: GotyQuestion,
+
+    @field:Positive
+    val year: Int,
 
     @field:NotEmpty
     val tiePoints: List<Int>,
+
+    @field:NotNull
+    val defaultLocalTimeZone: ZoneId,
 
     @field:NotNull
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) val deadline: ZonedDateTime,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/configuration/DefaultProperties.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/configuration/DefaultProperties.kt
@@ -14,7 +14,7 @@ import java.time.ZoneId
 
 fun DefaultProperties.toProperties() = Properties(
     title = this.title,
-    goty = this.goty,
+    gotyQuestion = this.gotyQuestion,
     year = this.year,
     tiePoints = this.tiePoints,
     deadline = this.deadline,
@@ -30,7 +30,7 @@ data class DefaultProperties(
     val title: String,
 
     @field:NotNull
-    val goty: GotyQuestion,
+    val gotyQuestion: GotyQuestion,
 
     @field:Positive
     val year: Int,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/GotyQuestion.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/GotyQuestion.kt
@@ -1,0 +1,7 @@
+package com.aleinin.goty.properties
+
+data class GotyQuestion(
+    val title: String,
+    val question: String,
+    val rules: List<String>
+)

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/GotyQuestionResponse.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/GotyQuestionResponse.kt
@@ -1,0 +1,7 @@
+package com.aleinin.goty.properties
+
+data class GotyQuestionResponse(
+    val title: ResolvedTemplate,
+    val question: ResolvedTemplate,
+    val rules: List<ResolvedTemplate>
+)

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/Properties.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/Properties.kt
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime
 data class Properties(
     val title: String,
     val year: Int,
-    val goty: GotyQuestion,
+    val gotyQuestion: GotyQuestion,
     val tiePoints: List<Int>,
     val deadline: ZonedDateTime,
     val hasGiveaway: Boolean,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/Properties.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/Properties.kt
@@ -1,17 +1,20 @@
 package com.aleinin.goty.properties
 
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 data class Properties(
-    val gotyYear: Int,
+    val title: String,
+    val year: Int,
+    val goty: GotyQuestion,
     val tiePoints: List<Int>,
     val deadline: ZonedDateTime,
     val hasGiveaway: Boolean,
     val giveawayAmountUSD: Int,
+    val defaultLocalTimeZone: ZoneId?
 ) {
     init {
         require(tiePoints.isNotEmpty()) { "tiePoints must not be empty" }
         require(tiePoints.sortedDescending() == tiePoints) { "tiePoints must be in descending order"}
-        require(giveawayAmountUSD >= 0) { "giveawayAmountUSD must be greater than or equal to 0" }
     }
 }

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesController.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesController.kt
@@ -5,8 +5,9 @@ import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-
+import java.time.ZoneId
 
 @CrossOrigin
 @RestController
@@ -15,9 +16,12 @@ class PropertiesController(
 ) {
 
     @GetMapping("/properties")
-    fun getProperties() = propertiesService.getProperties()
+    fun getProperties(@RequestParam(required = false) localTimeZone: ZoneId?) = propertiesService.getPropertiesResponse(localTimeZone)
 
     @PutMapping("/properties")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    fun putProperties(@RequestBody request: Properties) = propertiesService.replaceProperties(request)
+    fun putProperties(
+            @RequestParam(required = false) localTimeZone: ZoneId?,
+            @RequestBody request: Properties
+    ) = propertiesService.replaceProperties(request, localTimeZone)
 }

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesDocument.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesDocument.kt
@@ -7,7 +7,7 @@ data class PropertiesDocument(
     val id: String,
     val title: String,
     val year: Int,
-    val goty: GotyQuestion,
+    val gotyQuestion: GotyQuestion,
     val tiePoints: List<Int>,
     val deadline: Instant,
     val zoneId: ZoneId,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesRepository.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesRepository.kt
@@ -5,20 +5,26 @@ import java.util.Optional
 
 fun Properties.toDocument() = PropertiesDocument(
     id = PropertiesRepository.PROPERTIES_ID,
-    gotyYear = this.gotyYear,
+    title = this.title,
+    goty = this.goty,
+    year = this.year,
     tiePoints = this.tiePoints,
     deadline = this.deadline.toInstant(),
     zoneId = this.deadline.zone,
     hasGiveaway = this.hasGiveaway,
-    giveawayAmountUSD = this.giveawayAmountUSD
+    giveawayAmountUSD = this.giveawayAmountUSD,
+    defaultLocalTimeZone = this.defaultLocalTimeZone
 )
 
 fun PropertiesDocument.toProperties() = Properties(
-    gotyYear = this.gotyYear,
+    year = this.year,
+    title = this.title,
+    goty = this.goty,
     tiePoints = this.tiePoints,
     deadline = this.deadline.atZone(this.zoneId),
     hasGiveaway = this.hasGiveaway,
-    giveawayAmountUSD = this.giveawayAmountUSD
+    giveawayAmountUSD = this.giveawayAmountUSD,
+    defaultLocalTimeZone = this.defaultLocalTimeZone
 )
 
 @Repository

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesRepository.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesRepository.kt
@@ -6,7 +6,7 @@ import java.util.Optional
 fun Properties.toDocument() = PropertiesDocument(
     id = PropertiesRepository.PROPERTIES_ID,
     title = this.title,
-    goty = this.goty,
+    gotyQuestion = this.gotyQuestion,
     year = this.year,
     tiePoints = this.tiePoints,
     deadline = this.deadline.toInstant(),
@@ -19,7 +19,7 @@ fun Properties.toDocument() = PropertiesDocument(
 fun PropertiesDocument.toProperties() = Properties(
     year = this.year,
     title = this.title,
-    goty = this.goty,
+    gotyQuestion = this.gotyQuestion,
     tiePoints = this.tiePoints,
     deadline = this.deadline.atZone(this.zoneId),
     hasGiveaway = this.hasGiveaway,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesResponse.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesResponse.kt
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime
 data class PropertiesResponse(
     val title: ResolvedTemplate,
     val year: Int,
-    val goty: GotyQuestionResponse,
+    val gotyQuestion: GotyQuestionResponse,
     val tiePoints: List<Int>,
     val deadline: ZonedDateTime,
     val hasGiveaway: Boolean,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesResponse.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesResponse.kt
@@ -1,16 +1,14 @@
 package com.aleinin.goty.properties
 
-import java.time.Instant
 import java.time.ZoneId
+import java.time.ZonedDateTime
 
-data class PropertiesDocument(
-    val id: String,
-    val title: String,
+data class PropertiesResponse(
+    val title: ResolvedTemplate,
     val year: Int,
-    val goty: GotyQuestion,
+    val goty: GotyQuestionResponse,
     val tiePoints: List<Int>,
-    val deadline: Instant,
-    val zoneId: ZoneId,
+    val deadline: ZonedDateTime,
     val hasGiveaway: Boolean,
     val giveawayAmountUSD: Int,
     val defaultLocalTimeZone: ZoneId?

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesService.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesService.kt
@@ -4,19 +4,35 @@ import com.aleinin.goty.configuration.DefaultProperties
 import com.aleinin.goty.configuration.toProperties
 import org.springframework.stereotype.Service
 import org.springframework.validation.annotation.Validated
+import java.time.ZoneId
 
 @Service
 class PropertiesService(
     private val propertiesRepository: PropertiesRepository,
+    private val templateService: TemplateService,
     @Validated private val defaultProperties: DefaultProperties
 ) {
 
-    fun getProperties(): Properties = propertiesRepository
-        .findProperties()
-        .orElseGet { defaultProperties.toProperties() }
+    fun getProperties(): Properties = propertiesRepository.findProperties()
+        .orElseGet {defaultProperties.toProperties() }
 
-    fun replaceProperties(request: Properties): Properties {
-        return propertiesRepository.replaceProperties(request)
+    fun getPropertiesResponse(localTimeZone: ZoneId?): PropertiesResponse = toResponse(getProperties(), localTimeZone)
+
+    fun replaceProperties(request: Properties, localTimeZone: ZoneId?): PropertiesResponse {
+        return toResponse(propertiesRepository.replaceProperties(request), localTimeZone)
+    }
+
+    fun toResponse(properties: Properties, localTimeZone: ZoneId?): PropertiesResponse {
+        return PropertiesResponse(
+            title = templateService.toResolvedTemplate(properties.title, properties, localTimeZone),
+            year = properties.year,
+            goty = templateService.toGotyQuestionResponse(properties.goty, properties, localTimeZone),
+            tiePoints = properties.tiePoints,
+            deadline = properties.deadline,
+            giveawayAmountUSD = properties.giveawayAmountUSD,
+            hasGiveaway = properties.hasGiveaway,
+            defaultLocalTimeZone = properties.defaultLocalTimeZone
+        )
     }
 
 }

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesService.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/PropertiesService.kt
@@ -26,7 +26,7 @@ class PropertiesService(
         return PropertiesResponse(
             title = templateService.toResolvedTemplate(properties.title, properties, localTimeZone),
             year = properties.year,
-            goty = templateService.toGotyQuestionResponse(properties.goty, properties, localTimeZone),
+            gotyQuestion = templateService.toGotyQuestionResponse(properties.gotyQuestion, properties, localTimeZone),
             tiePoints = properties.tiePoints,
             deadline = properties.deadline,
             giveawayAmountUSD = properties.giveawayAmountUSD,

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/ResolvedTemplate.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/ResolvedTemplate.kt
@@ -1,0 +1,6 @@
+package com.aleinin.goty.properties
+
+data class ResolvedTemplate(
+    val template: String,
+    val text: String,
+)

--- a/goty-server/src/main/kotlin/com/aleinin/goty/properties/TemplateService.kt
+++ b/goty-server/src/main/kotlin/com/aleinin/goty/properties/TemplateService.kt
@@ -1,0 +1,41 @@
+package com.aleinin.goty.properties
+
+import org.springframework.stereotype.Service
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Service
+class TemplateService {
+    private val formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a")
+
+    val tokenMap = mapOf(
+        "\${year}" to { properties: Properties, _: ZoneId? -> properties.year.toString() },
+        "\${deadline}" to { properties: Properties, localTimeZone: ZoneId? -> getDeadlineAtTimeZone(properties, localTimeZone) },
+        "\${maxGames}" to { properties: Properties, _: ZoneId? -> properties.tiePoints.size.toString() }
+    )
+    fun toGotyQuestionResponse(gotyQuestion: GotyQuestion, properties: Properties, localTimeZone: ZoneId?) = GotyQuestionResponse(
+        title = toResolvedTemplate(gotyQuestion.title, properties, localTimeZone),
+        question = toResolvedTemplate(gotyQuestion.question, properties, localTimeZone),
+        rules = gotyQuestion.rules.map { toResolvedTemplate(it, properties, localTimeZone) }
+    )
+
+    fun toResolvedTemplate(templateString: String, properties: Properties, localTimeZone: ZoneId?): ResolvedTemplate {
+        var text = templateString
+        tokenMap.forEach { (token, translationFn) ->
+            text = text.replace(token, translationFn(properties, localTimeZone))
+        }
+        return ResolvedTemplate(template = templateString, text = text)
+    }
+
+    private fun getDeadlineAtTimeZone(properties: Properties, localTimeZone: ZoneId?): String {
+        val timeZone =
+            if (localTimeZone != null) {
+                localTimeZone
+            } else if (properties.defaultLocalTimeZone != null) {
+                properties.defaultLocalTimeZone
+            } else {
+                ZoneId.of("UTC")
+            }
+        return properties.deadline.withZoneSameInstant(timeZone).format(formatter)
+    }
+}

--- a/goty-server/src/main/resources/application.yml
+++ b/goty-server/src/main/resources/application.yml
@@ -1,9 +1,18 @@
 goty:
   default:
-    gotyYear: 2022
+    title: Top Games of the Year ${year}
+    goty:
+      title: Games of the Year
+      question: What are your favorite game(s) of ${year}?
+      rules:
+        - Voting closes ${deadline}
+        - You may nominate as many games as you want up to a total of ${maxGames}
+        - Must have been released in ${year}
+    year: 2022
     deadline: 2023-01-01T00:00:00-05:00
     hasGiveaway: true
     giveawayAmountUSD: 25
+    defaultLocalTimeZone: America/New_York
     tiePoints:
       - 15
       - 13

--- a/goty-server/src/main/resources/application.yml
+++ b/goty-server/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 goty:
   default:
     title: Top Games of the Year ${year}
-    goty:
+    gotyQuestion:
       title: Games of the Year
       question: What are your favorite game(s) of ${year}?
       rules:

--- a/goty-server/src/test/kotlin/com/aleinin/goty/TimeHelper.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/TimeHelper.kt
@@ -1,7 +1,6 @@
 package com.aleinin.goty
 
-import java.time.ZonedDateTime
+import java.time.ZoneId
 
-fun tomorrow(): ZonedDateTime = ZonedDateTime.now().plusDays(1)
-
-fun thisYear(): Int = ZonedDateTime.now().year
+val UTC = ZoneId.of("Etc/GMT");
+val EasternTime = ZoneId.of("America/New_York")

--- a/goty-server/src/test/kotlin/com/aleinin/goty/TimeHelper.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/TimeHelper.kt
@@ -2,5 +2,5 @@ package com.aleinin.goty
 
 import java.time.ZoneId
 
-val UTC = ZoneId.of("Etc/GMT");
+val UTC = ZoneId.of("Etc/GMT")
 val EasternTime = ZoneId.of("America/New_York")

--- a/goty-server/src/test/kotlin/com/aleinin/goty/configuration/DefaultPropertiesTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/configuration/DefaultPropertiesTest.kt
@@ -1,28 +1,35 @@
 package com.aleinin.goty.configuration
 
+import com.aleinin.goty.properties.GotyQuestion
 import com.aleinin.goty.properties.Properties
-import com.aleinin.goty.thisYear
-import com.aleinin.goty.tomorrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
 
 
 internal class DefaultPropertiesTest {
     @Test
     fun `Should convert DefaultProperties to Properties`() {
         val defaultProperties = DefaultProperties(
-            gotyYear = thisYear(),
+            title = "Hello",
+            goty = GotyQuestion(title = "GOTY", question = "?", rules = listOf("None!")),
+            year = 2022,
             tiePoints = listOf(3, 2, 1),
-            deadline = tomorrow(),
+            deadline = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")),
             hasGiveaway = true,
+            defaultLocalTimeZone = ZoneId.of("Etc/GMT"),
             giveawayAmountUSD = 5
         )
         val expected = Properties(
-            gotyYear = defaultProperties.gotyYear,
+            title = defaultProperties.title,
+            goty = defaultProperties.goty,
+            year = defaultProperties.year,
             tiePoints = defaultProperties.tiePoints,
             deadline = defaultProperties.deadline,
-            defaultProperties.hasGiveaway,
-            defaultProperties.giveawayAmountUSD
+            hasGiveaway = defaultProperties.hasGiveaway,
+            giveawayAmountUSD = defaultProperties.giveawayAmountUSD,
+            defaultLocalTimeZone = defaultProperties.defaultLocalTimeZone
         )
         val actual = defaultProperties.toProperties()
         assertEquals(expected, actual)

--- a/goty-server/src/test/kotlin/com/aleinin/goty/configuration/DefaultPropertiesTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/configuration/DefaultPropertiesTest.kt
@@ -13,7 +13,7 @@ internal class DefaultPropertiesTest {
     fun `Should convert DefaultProperties to Properties`() {
         val defaultProperties = DefaultProperties(
             title = "Hello",
-            goty = GotyQuestion(title = "GOTY", question = "?", rules = listOf("None!")),
+            gotyQuestion = GotyQuestion(title = "GOTY", question = "?", rules = listOf("None!")),
             year = 2022,
             tiePoints = listOf(3, 2, 1),
             deadline = ZonedDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")),
@@ -23,7 +23,7 @@ internal class DefaultPropertiesTest {
         )
         val expected = Properties(
             title = defaultProperties.title,
-            goty = defaultProperties.goty,
+            gotyQuestion = defaultProperties.gotyQuestion,
             year = defaultProperties.year,
             tiePoints = defaultProperties.tiePoints,
             deadline = defaultProperties.deadline,

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesControllerTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesControllerTest.kt
@@ -56,7 +56,7 @@ internal class PropertiesControllerTest {
         id = "id",
         title = "goty",
         year = 2050,
-        goty = GotyQuestion("title", "question", emptyList()),
+        gotyQuestion = GotyQuestion("title", "question", emptyList()),
         tiePoints = listOf(3, 2, 1),
         deadline = deadline.toInstant(),
         zoneId = UTC,
@@ -68,7 +68,7 @@ internal class PropertiesControllerTest {
     private val basicRequest = Properties(
         title = "goty",
         year = 2050,
-        goty = GotyQuestion("title", "question", emptyList()),
+        gotyQuestion = GotyQuestion("title", "question", emptyList()),
         tiePoints = listOf(15, 13, 11),
         deadline = deadline,
         hasGiveaway = false,
@@ -82,9 +82,9 @@ internal class PropertiesControllerTest {
         val expected = PropertiesResponse(
             title = ResolvedTemplate(mockPropertiesDocument.title, mockPropertiesDocument.title),
             year = mockPropertiesDocument.year,
-            goty = GotyQuestionResponse(
-                ResolvedTemplate(mockPropertiesDocument.goty.title, mockPropertiesDocument.goty.title),
-                ResolvedTemplate(mockPropertiesDocument.goty.question, mockPropertiesDocument.goty.question),
+            gotyQuestion = GotyQuestionResponse(
+                ResolvedTemplate(mockPropertiesDocument.gotyQuestion.title, mockPropertiesDocument.gotyQuestion.title),
+                ResolvedTemplate(mockPropertiesDocument.gotyQuestion.question, mockPropertiesDocument.gotyQuestion.question),
                 emptyList()
             ),
             tiePoints = mockPropertiesDocument.tiePoints,
@@ -103,13 +103,13 @@ internal class PropertiesControllerTest {
     fun `Should get the default properties if none are stored`() {
         whenever(propertiesDocumentRepository.findById(any())).thenReturn(Optional.empty())
         val default = defaultProperties.toProperties()
-        val rule = defaultProperties.goty.rules[0]
+        val rule = defaultProperties.gotyQuestion.rules[0]
         val expected = PropertiesResponse(
             title = ResolvedTemplate(default.title, default.title),
             year = default.year,
-            goty = GotyQuestionResponse(
-                ResolvedTemplate(default.goty.title, default.goty.title),
-                ResolvedTemplate(default.goty.question, "What are your favorite game(s) of ${defaultProperties.year}?"),
+            gotyQuestion = GotyQuestionResponse(
+                ResolvedTemplate(default.gotyQuestion.title, default.gotyQuestion.title),
+                ResolvedTemplate(default.gotyQuestion.question, "What are your favorite game(s) of ${defaultProperties.year}?"),
                 listOf(ResolvedTemplate(rule, rule))
             ),
             tiePoints = default.tiePoints,
@@ -130,7 +130,7 @@ internal class PropertiesControllerTest {
         val expectedDocument = PropertiesDocument(
             id = PropertiesRepository.PROPERTIES_ID,
             title = basicRequest.title,
-            goty = GotyQuestion(basicRequest.goty.title, basicRequest.goty.question, basicRequest.goty.rules),
+            gotyQuestion = GotyQuestion(basicRequest.gotyQuestion.title, basicRequest.gotyQuestion.question, basicRequest.gotyQuestion.rules),
             year = basicRequest.year,
             tiePoints = basicRequest.tiePoints,
             deadline = basicRequest.deadline.toInstant(),
@@ -141,9 +141,9 @@ internal class PropertiesControllerTest {
         )
         val expectedResponse = PropertiesResponse(
             title = ResolvedTemplate(basicRequest.title, basicRequest.title),
-            goty = GotyQuestionResponse(
-                ResolvedTemplate(basicRequest.goty.title, basicRequest.goty.title),
-                ResolvedTemplate(basicRequest.goty.question, basicRequest.goty.question),
+            gotyQuestion = GotyQuestionResponse(
+                ResolvedTemplate(basicRequest.gotyQuestion.title, basicRequest.gotyQuestion.title),
+                ResolvedTemplate(basicRequest.gotyQuestion.question, basicRequest.gotyQuestion.question),
                 emptyList()
             ),
             year = basicRequest.year,

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesControllerTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesControllerTest.kt
@@ -1,9 +1,8 @@
 package com.aleinin.goty.properties
 
+import com.aleinin.goty.UTC
 import com.aleinin.goty.configuration.DefaultProperties
 import com.aleinin.goty.configuration.toProperties
-import com.aleinin.goty.thisYear
-import com.aleinin.goty.tomorrow
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -27,7 +26,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util.Optional
 
@@ -50,33 +49,49 @@ internal class PropertiesControllerTest {
     @Captor
     lateinit var documentCaptor: ArgumentCaptor<PropertiesDocument>
 
+    private val deadline = ZonedDateTime.of(2023, 11, 24, 0, 0, 0, 0, UTC).truncatedTo(ChronoUnit.SECONDS)
+
+
     private val mockPropertiesDocument = PropertiesDocument(
         id = "id",
-        gotyYear = thisYear(),
+        title = "goty",
+        year = 2050,
+        goty = GotyQuestion("title", "question", emptyList()),
         tiePoints = listOf(3, 2, 1),
-        deadline = tomorrow().toInstant(),
-        zoneId = ZoneId.systemDefault(),
+        deadline = deadline.toInstant(),
+        zoneId = UTC,
         hasGiveaway = true,
-        giveawayAmountUSD = 0
+        giveawayAmountUSD = 0,
+        defaultLocalTimeZone = UTC
     )
 
     private val basicRequest = Properties(
-        gotyYear = thisYear(),
+        title = "goty",
+        year = 2050,
+        goty = GotyQuestion("title", "question", emptyList()),
         tiePoints = listOf(15, 13, 11),
-        deadline = tomorrow().truncatedTo(ChronoUnit.SECONDS),
+        deadline = deadline,
         hasGiveaway = false,
-        giveawayAmountUSD = 15
+        giveawayAmountUSD = 15,
+        defaultLocalTimeZone = UTC
     )
 
     @Test
-    fun `Should get stored properties if available`() {
+    fun `Should get properties response from database if available`() {
         whenever(propertiesDocumentRepository.findById(any())).thenReturn(Optional.of(mockPropertiesDocument))
-        val expected = Properties(
-            gotyYear = mockPropertiesDocument.gotyYear,
+        val expected = PropertiesResponse(
+            title = ResolvedTemplate(mockPropertiesDocument.title, mockPropertiesDocument.title),
+            year = mockPropertiesDocument.year,
+            goty = GotyQuestionResponse(
+                ResolvedTemplate(mockPropertiesDocument.goty.title, mockPropertiesDocument.goty.title),
+                ResolvedTemplate(mockPropertiesDocument.goty.question, mockPropertiesDocument.goty.question),
+                emptyList()
+            ),
             tiePoints = mockPropertiesDocument.tiePoints,
             deadline = mockPropertiesDocument.deadline.atZone(mockPropertiesDocument.zoneId),
             hasGiveaway = mockPropertiesDocument.hasGiveaway,
-            giveawayAmountUSD = mockPropertiesDocument.giveawayAmountUSD
+            giveawayAmountUSD = mockPropertiesDocument.giveawayAmountUSD,
+            defaultLocalTimeZone = mockPropertiesDocument.defaultLocalTimeZone
         )
         val expectedJsonContent = objectMapper.writeValueAsString(expected)
         mockMvc.perform(get("/properties"))
@@ -87,7 +102,22 @@ internal class PropertiesControllerTest {
     @Test
     fun `Should get the default properties if none are stored`() {
         whenever(propertiesDocumentRepository.findById(any())).thenReturn(Optional.empty())
-        val expected = defaultProperties.toProperties()
+        val default = defaultProperties.toProperties()
+        val rule = defaultProperties.goty.rules[0]
+        val expected = PropertiesResponse(
+            title = ResolvedTemplate(default.title, default.title),
+            year = default.year,
+            goty = GotyQuestionResponse(
+                ResolvedTemplate(default.goty.title, default.goty.title),
+                ResolvedTemplate(default.goty.question, "What are your favorite game(s) of ${defaultProperties.year}?"),
+                listOf(ResolvedTemplate(rule, rule))
+            ),
+            tiePoints = default.tiePoints,
+            deadline = default.deadline,
+            hasGiveaway = default.hasGiveaway,
+            giveawayAmountUSD = default.giveawayAmountUSD,
+            defaultLocalTimeZone = default.defaultLocalTimeZone
+        )
         val expectedJsonContent = objectMapper.writeValueAsString(expected)
         mockMvc.perform(get("/properties"))
             .andExpect(status().isOk)
@@ -99,20 +129,38 @@ internal class PropertiesControllerTest {
     fun `Should replace the properties`() {
         val expectedDocument = PropertiesDocument(
             id = PropertiesRepository.PROPERTIES_ID,
-            gotyYear = basicRequest.gotyYear,
+            title = basicRequest.title,
+            goty = GotyQuestion(basicRequest.goty.title, basicRequest.goty.question, basicRequest.goty.rules),
+            year = basicRequest.year,
             tiePoints = basicRequest.tiePoints,
             deadline = basicRequest.deadline.toInstant(),
             zoneId = basicRequest.deadline.zone,
             hasGiveaway = basicRequest.hasGiveaway,
-            giveawayAmountUSD = basicRequest.giveawayAmountUSD
+            giveawayAmountUSD = basicRequest.giveawayAmountUSD,
+            defaultLocalTimeZone = basicRequest.defaultLocalTimeZone
+        )
+        val expectedResponse = PropertiesResponse(
+            title = ResolvedTemplate(basicRequest.title, basicRequest.title),
+            goty = GotyQuestionResponse(
+                ResolvedTemplate(basicRequest.goty.title, basicRequest.goty.title),
+                ResolvedTemplate(basicRequest.goty.question, basicRequest.goty.question),
+                emptyList()
+            ),
+            year = basicRequest.year,
+            tiePoints = basicRequest.tiePoints,
+            deadline = basicRequest.deadline,
+            hasGiveaway = basicRequest.hasGiveaway,
+            giveawayAmountUSD = basicRequest.giveawayAmountUSD,
+            defaultLocalTimeZone = basicRequest.defaultLocalTimeZone
         )
         val requestAsJsonString = objectMapper.writeValueAsString(basicRequest)
+        val responseAsJsonString = objectMapper.writeValueAsString(expectedResponse)
         whenever(propertiesDocumentRepository.save(Mockito.any(PropertiesDocument::class.java))).thenReturn(expectedDocument)
         mockMvc.perform(put("/properties")
             .contentType(MediaType.APPLICATION_JSON)
             .content(requestAsJsonString))
             .andExpect(status().isOk)
-            .andExpect(content().json(requestAsJsonString, true))
+            .andExpect(content().json(responseAsJsonString, true))
         verify(propertiesDocumentRepository, times(1)).save(capture(documentCaptor))
         val actualDocument = documentCaptor.firstValue
         assertEquals(expectedDocument, actualDocument)

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesRepositoryTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesRepositoryTest.kt
@@ -31,7 +31,7 @@ internal class PropertiesRepositoryTest {
         val mockDocument = PropertiesDocument(
             id = propertiesId,
             title = "Hello World",
-            goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+            gotyQuestion = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
             year = deadline.year,
             tiePoints = listOf(3, 2, 1),
             deadline = deadline.toInstant(),
@@ -44,7 +44,7 @@ internal class PropertiesRepositoryTest {
         val expected = Optional.of(
             Properties(
                 title = "Hello World",
-                goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+                gotyQuestion = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
                 year = deadline.year,
                 tiePoints = listOf(3, 2, 1),
                 deadline = deadline,
@@ -61,7 +61,7 @@ internal class PropertiesRepositoryTest {
     fun `Should store Properties`() {
         val expected = Properties(
             title = "Hello World",
-            goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+            gotyQuestion = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
             year = deadline.year,
             tiePoints = listOf(3, 2, 1),
             deadline = deadline,
@@ -72,7 +72,7 @@ internal class PropertiesRepositoryTest {
         val expectedDocument = PropertiesDocument(
             id = "properties",
             title = "Hello World",
-            goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+            gotyQuestion = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
             year = deadline.year,
             tiePoints = listOf(3, 2, 1),
             deadline = deadline.toInstant(),

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesRepositoryTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.aleinin.goty.properties
 
-import com.aleinin.goty.thisYear
+import com.aleinin.goty.EasternTime
+import com.aleinin.goty.UTC
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -9,7 +10,6 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util.Optional
@@ -24,26 +24,32 @@ internal class PropertiesRepositoryTest {
 
     private val propertiesId = PropertiesRepository.PROPERTIES_ID
 
-    private val deadline = ZonedDateTime.now().plusSeconds(3600).truncatedTo(ChronoUnit.SECONDS)
+    private val deadline = ZonedDateTime.of(2023, 11, 24, 0, 0, 0, 0, UTC).truncatedTo(ChronoUnit.SECONDS)
 
     @Test
     fun `Should get the Properties`() {
         val mockDocument = PropertiesDocument(
             id = propertiesId,
-            gotyYear = deadline.year,
+            title = "Hello World",
+            goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+            year = deadline.year,
             tiePoints = listOf(3, 2, 1),
             deadline = deadline.toInstant(),
-            zoneId = ZoneId.systemDefault(),
+            zoneId = UTC,
             hasGiveaway = true,
+            defaultLocalTimeZone = EasternTime,
             giveawayAmountUSD = 25
         )
         whenever(propertiesDocumentRepository.findById(propertiesId)).thenReturn(Optional.of(mockDocument))
         val expected = Optional.of(
             Properties(
-                gotyYear = deadline.year,
+                title = "Hello World",
+                goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+                year = deadline.year,
                 tiePoints = listOf(3, 2, 1),
                 deadline = deadline,
                 hasGiveaway = true,
+                defaultLocalTimeZone = EasternTime,
                 giveawayAmountUSD = 25
             )
         )
@@ -54,19 +60,25 @@ internal class PropertiesRepositoryTest {
     @Test
     fun `Should store Properties`() {
         val expected = Properties(
-            gotyYear = thisYear(),
+            title = "Hello World",
+            goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+            year = deadline.year,
             tiePoints = listOf(3, 2, 1),
             deadline = deadline,
             hasGiveaway = true,
+            defaultLocalTimeZone = EasternTime,
             giveawayAmountUSD = 25
         )
         val expectedDocument = PropertiesDocument(
-            id = propertiesId,
-            gotyYear = thisYear(),
+            id = "properties",
+            title = "Hello World",
+            goty = GotyQuestion(title = "GOTY", question = "Question", rules = listOf("rule")),
+            year = deadline.year,
             tiePoints = listOf(3, 2, 1),
             deadline = deadline.toInstant(),
-            zoneId = ZoneId.systemDefault(),
+            zoneId = UTC,
             hasGiveaway = true,
+            defaultLocalTimeZone = EasternTime,
             giveawayAmountUSD = 25
         )
         whenever(propertiesDocumentRepository.save(Mockito.any(PropertiesDocument::class.java))).thenReturn(expectedDocument)

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesServiceTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesServiceTest.kt
@@ -1,16 +1,19 @@
 package com.aleinin.goty.properties
 
+import com.aleinin.goty.EasternTime
+import com.aleinin.goty.UTC
 import com.aleinin.goty.configuration.DefaultProperties
 import com.aleinin.goty.configuration.toProperties
-import com.aleinin.goty.thisYear
-import com.aleinin.goty.tomorrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import java.time.ZonedDateTime
 import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
@@ -18,28 +21,49 @@ internal class PropertiesServiceTest {
     @Mock
     lateinit var propertiesRepository: PropertiesRepository
 
+    @Mock
+    lateinit var templateService: TemplateService
+
     lateinit var propertiesService: PropertiesService
 
     private val defaultProperties = DefaultProperties(
-        gotyYear = thisYear(),
+        title = "Default Title",
+        goty = GotyQuestion(title = "Default tile", question = "Defautl question", rules = listOf("Default rules")),
+        year = 2023,
         tiePoints = listOf(9, 8, 7),
-        deadline = tomorrow(),
-        hasGiveaway = false,
-        giveawayAmountUSD = 0
+        deadline = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, UTC),
+        defaultLocalTimeZone = EasternTime,
+        hasGiveaway = true,
+        giveawayAmountUSD = 25
     )
 
+    private val deadline = ZonedDateTime.of(2088, 1, 1, 0, 0, 0, 0, UTC)
+
     @BeforeEach
-    fun setUp() {
-        propertiesService = PropertiesService(propertiesRepository, defaultProperties)
+    fun setup() {
+        propertiesService = PropertiesService(propertiesRepository, templateService,  defaultProperties)
+    }
+
+    private fun setupTemplateMock() {
+        whenever(templateService.toResolvedTemplate(anyString(), any(), any())).thenAnswer { ResolvedTemplate(it.getArgument(0), it.getArgument(0))}
+        whenever(templateService.toGotyQuestionResponse(any(), any(), any())).thenAnswer {
+            GotyQuestionResponse(
+                title = ResolvedTemplate(it.getArgument<GotyQuestion>(0).title, it.getArgument<GotyQuestion>(0).title),
+                question = ResolvedTemplate(it.getArgument<GotyQuestion>(0).question, it.getArgument<GotyQuestion>(0).question),
+                rules = it.getArgument<GotyQuestion>(0).rules.map {rule -> ResolvedTemplate(rule, rule) })
+        }
     }
 
     @Test
     fun `Should return the stored configuration`() {
         val expectedProperties = Properties(
-            gotyYear = thisYear(),
+            title = "Game of the Year",
+            year = 2023,
+            goty=GotyQuestion(title = "Title", question="Question", rules= listOf("Rules")),
             tiePoints = listOf(3, 2, 1),
-            deadline = tomorrow(),
+            deadline = deadline,
             hasGiveaway = false,
+            defaultLocalTimeZone = UTC,
             giveawayAmountUSD = 0
         )
         whenever(propertiesRepository.findProperties()).thenReturn(Optional.of(expectedProperties))
@@ -55,17 +79,88 @@ internal class PropertiesServiceTest {
     }
 
     @Test
+    fun `Should return the stored configuration response`() {
+        setupTemplateMock()
+        val storedProperties = Properties(
+                title = "Game of the Year",
+                year = 2023,
+                goty=GotyQuestion(title = "Title", question="Question", rules= listOf("Rules")),
+                tiePoints = listOf(3, 2, 1),
+                deadline = deadline,
+                hasGiveaway = false,
+                defaultLocalTimeZone = UTC,
+                giveawayAmountUSD = 0
+        )
+        val expectedResponse = PropertiesResponse(
+            title = ResolvedTemplate(storedProperties.title, storedProperties.title),
+            year = storedProperties.year,
+            goty = GotyQuestionResponse(
+                ResolvedTemplate(storedProperties.goty.title, storedProperties.goty.title),
+                ResolvedTemplate(storedProperties.goty.question, storedProperties.goty.question),
+                storedProperties.goty.rules.map { ResolvedTemplate(it, it) }
+            ),
+            tiePoints = storedProperties.tiePoints,
+            deadline = storedProperties.deadline,
+            hasGiveaway = storedProperties.hasGiveaway,
+            defaultLocalTimeZone = storedProperties.defaultLocalTimeZone,
+            giveawayAmountUSD = storedProperties.giveawayAmountUSD
+        )
+        whenever(propertiesRepository.findProperties()).thenReturn(Optional.of(storedProperties))
+        val actualResponse = propertiesService.getPropertiesResponse(UTC)
+        assertEquals(expectedResponse, actualResponse)
+    }
+
+    @Test
+    fun `Should return the default properties as response if none stored`() {
+        setupTemplateMock()
+        whenever(propertiesRepository.findProperties()).thenReturn(Optional.empty())
+        val actual = propertiesService.getPropertiesResponse(EasternTime)
+        val expected = PropertiesResponse(
+            title = ResolvedTemplate(defaultProperties.title, defaultProperties.title),
+            year = defaultProperties.year,
+            goty = GotyQuestionResponse(
+                    ResolvedTemplate(defaultProperties.goty.title, defaultProperties.goty.title),
+                    ResolvedTemplate(defaultProperties.goty.question, defaultProperties.goty.question),
+                    defaultProperties.goty.rules.map { ResolvedTemplate(it, it) }
+            ),
+            tiePoints = defaultProperties.tiePoints,
+            deadline = defaultProperties.deadline,
+            hasGiveaway = defaultProperties.hasGiveaway,
+            defaultLocalTimeZone = defaultProperties.defaultLocalTimeZone,
+            giveawayAmountUSD = defaultProperties.giveawayAmountUSD
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `Should accept a new configuration`() {
-        val expectedConfig = Properties(
-            gotyYear = thisYear(),
+        setupTemplateMock()
+        val request = Properties(
+            title = "new title",
+            goty = GotyQuestion(title = "new goty title", question = "new goty question", rules = listOf("new goty rules")),
+            year = 2077,
             tiePoints = listOf(6, 5, 4),
-            deadline = tomorrow(),
+            deadline = deadline,
             hasGiveaway = false,
+            defaultLocalTimeZone = null,
             giveawayAmountUSD = 0
         )
-        whenever(propertiesRepository.replaceProperties(expectedConfig)).thenReturn(expectedConfig)
-        val actualConfig = propertiesService.replaceProperties(expectedConfig)
-        assertEquals(expectedConfig, actualConfig)
-
+        val expectedResponse = PropertiesResponse(
+            title = ResolvedTemplate("new title", "new title"),
+            goty = GotyQuestionResponse(
+                title = ResolvedTemplate("new goty title", "new goty title"),
+                question = ResolvedTemplate("new goty question", "new goty question"),
+                rules = listOf(ResolvedTemplate("new goty rules", "new goty rules"))
+            ),
+            year = 2077,
+            tiePoints = listOf(6, 5, 4),
+            deadline = deadline,
+            hasGiveaway = false,
+            defaultLocalTimeZone = null,
+            giveawayAmountUSD = 0
+        )
+        whenever(propertiesRepository.replaceProperties(any())).thenReturn(request)
+        val actualResponse = propertiesService.replaceProperties(request, EasternTime)
+        assertEquals(expectedResponse, actualResponse)
     }
 }

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesServiceTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesServiceTest.kt
@@ -28,7 +28,7 @@ internal class PropertiesServiceTest {
 
     private val defaultProperties = DefaultProperties(
         title = "Default Title",
-        goty = GotyQuestion(title = "Default tile", question = "Defautl question", rules = listOf("Default rules")),
+        gotyQuestion = GotyQuestion(title = "Default tile", question = "Defautl question", rules = listOf("Default rules")),
         year = 2023,
         tiePoints = listOf(9, 8, 7),
         deadline = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, UTC),
@@ -59,7 +59,7 @@ internal class PropertiesServiceTest {
         val expectedProperties = Properties(
             title = "Game of the Year",
             year = 2023,
-            goty=GotyQuestion(title = "Title", question="Question", rules= listOf("Rules")),
+            gotyQuestion = GotyQuestion(title = "Title", question="Question", rules= listOf("Rules")),
             tiePoints = listOf(3, 2, 1),
             deadline = deadline,
             hasGiveaway = false,
@@ -84,7 +84,7 @@ internal class PropertiesServiceTest {
         val storedProperties = Properties(
                 title = "Game of the Year",
                 year = 2023,
-                goty=GotyQuestion(title = "Title", question="Question", rules= listOf("Rules")),
+                gotyQuestion = GotyQuestion(title = "Title", question="Question", rules= listOf("Rules")),
                 tiePoints = listOf(3, 2, 1),
                 deadline = deadline,
                 hasGiveaway = false,
@@ -94,10 +94,10 @@ internal class PropertiesServiceTest {
         val expectedResponse = PropertiesResponse(
             title = ResolvedTemplate(storedProperties.title, storedProperties.title),
             year = storedProperties.year,
-            goty = GotyQuestionResponse(
-                ResolvedTemplate(storedProperties.goty.title, storedProperties.goty.title),
-                ResolvedTemplate(storedProperties.goty.question, storedProperties.goty.question),
-                storedProperties.goty.rules.map { ResolvedTemplate(it, it) }
+            gotyQuestion = GotyQuestionResponse(
+                ResolvedTemplate(storedProperties.gotyQuestion.title, storedProperties.gotyQuestion.title),
+                ResolvedTemplate(storedProperties.gotyQuestion.question, storedProperties.gotyQuestion.question),
+                storedProperties.gotyQuestion.rules.map { ResolvedTemplate(it, it) }
             ),
             tiePoints = storedProperties.tiePoints,
             deadline = storedProperties.deadline,
@@ -118,10 +118,10 @@ internal class PropertiesServiceTest {
         val expected = PropertiesResponse(
             title = ResolvedTemplate(defaultProperties.title, defaultProperties.title),
             year = defaultProperties.year,
-            goty = GotyQuestionResponse(
-                    ResolvedTemplate(defaultProperties.goty.title, defaultProperties.goty.title),
-                    ResolvedTemplate(defaultProperties.goty.question, defaultProperties.goty.question),
-                    defaultProperties.goty.rules.map { ResolvedTemplate(it, it) }
+            gotyQuestion = GotyQuestionResponse(
+                    ResolvedTemplate(defaultProperties.gotyQuestion.title, defaultProperties.gotyQuestion.title),
+                    ResolvedTemplate(defaultProperties.gotyQuestion.question, defaultProperties.gotyQuestion.question),
+                    defaultProperties.gotyQuestion.rules.map { ResolvedTemplate(it, it) }
             ),
             tiePoints = defaultProperties.tiePoints,
             deadline = defaultProperties.deadline,
@@ -137,7 +137,7 @@ internal class PropertiesServiceTest {
         setupTemplateMock()
         val request = Properties(
             title = "new title",
-            goty = GotyQuestion(title = "new goty title", question = "new goty question", rules = listOf("new goty rules")),
+            gotyQuestion = GotyQuestion(title = "new goty title", question = "new goty question", rules = listOf("new goty rules")),
             year = 2077,
             tiePoints = listOf(6, 5, 4),
             deadline = deadline,
@@ -147,7 +147,7 @@ internal class PropertiesServiceTest {
         )
         val expectedResponse = PropertiesResponse(
             title = ResolvedTemplate("new title", "new title"),
-            goty = GotyQuestionResponse(
+            gotyQuestion = GotyQuestionResponse(
                 title = ResolvedTemplate("new goty title", "new goty title"),
                 question = ResolvedTemplate("new goty question", "new goty question"),
                 rules = listOf(ResolvedTemplate("new goty rules", "new goty rules"))

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesTest.kt
@@ -14,7 +14,7 @@ internal class PropertiesTest {
             Properties(
                 title = "",
                 year = 2023,
-                goty = GotyQuestion("", "", emptyList()),
+                gotyQuestion = GotyQuestion("", "", emptyList()),
                 tiePoints = emptyList(),
                 hasGiveaway = false,
                 giveawayAmountUSD = 0,
@@ -30,7 +30,7 @@ internal class PropertiesTest {
             Properties(
                 title = "",
                 year = 2023,
-                goty = GotyQuestion("", "", emptyList()),
+                gotyQuestion = GotyQuestion("", "", emptyList()),
                 tiePoints = listOf(3, 1, 2),
                 hasGiveaway = false,
                 giveawayAmountUSD = 0,
@@ -44,7 +44,7 @@ internal class PropertiesTest {
     fun `Should accept valid props`() {
         val actual = Properties(
             title =  "",
-            goty = GotyQuestion("", "", emptyList()),
+            gotyQuestion = GotyQuestion("", "", emptyList()),
             year = 2023,
             tiePoints = listOf(3, 2, 1),
             hasGiveaway = false,

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/PropertiesTest.kt
@@ -1,22 +1,25 @@
 package com.aleinin.goty.properties
 
-import com.aleinin.goty.thisYear
-import com.aleinin.goty.tomorrow
+import com.aleinin.goty.UTC
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 
 internal class PropertiesTest {
+    private val testTime = ZonedDateTime.of(2023, 11, 24, 0, 0, 0, 0, UTC)
     @Test
     fun `Should not allow empty lists for tiePoints`() {
         assertThrows(IllegalArgumentException::class.java) {
             Properties(
-                gotyYear = thisYear(),
-                tiePoints = listOf(),
+                title = "",
+                year = 2023,
+                goty = GotyQuestion("", "", emptyList()),
+                tiePoints = emptyList(),
                 hasGiveaway = false,
                 giveawayAmountUSD = 0,
-                deadline = tomorrow()
+                deadline = testTime,
+                defaultLocalTimeZone = null
             )
         }
     }
@@ -25,37 +28,14 @@ internal class PropertiesTest {
     fun `Should not allow tiePoints in a non-descending order`() {
         assertThrows(IllegalArgumentException::class.java) {
             Properties(
-                gotyYear = thisYear(),
+                title = "",
+                year = 2023,
+                goty = GotyQuestion("", "", emptyList()),
                 tiePoints = listOf(3, 1, 2),
                 hasGiveaway = false,
                 giveawayAmountUSD = 0,
-                deadline = tomorrow()
-            )
-        }
-    }
-
-    @Test
-    fun `Should not allow negative giveAwayAmountUSD`() {
-        assertThrows(IllegalArgumentException::class.java) {
-            Properties(
-                gotyYear = thisYear(),
-                tiePoints = listOf(3, 2, 1),
-                hasGiveaway = false,
-                giveawayAmountUSD = -1,
-                deadline = tomorrow()
-            )
-        }
-    }
-
-    @Test
-    fun `Should not allow deadlines in the past`() {
-        assertThrows(IllegalArgumentException::class.java) {
-            Properties(
-                gotyYear = thisYear(),
-                tiePoints = listOf(3, 2, 1),
-                hasGiveaway = false,
-                giveawayAmountUSD = -1,
-                deadline = ZonedDateTime.now()
+                deadline = testTime,
+                defaultLocalTimeZone = null
             )
         }
     }
@@ -63,11 +43,14 @@ internal class PropertiesTest {
     @Test
     fun `Should accept valid props`() {
         val actual = Properties(
-            gotyYear = thisYear(),
+            title =  "",
+            goty = GotyQuestion("", "", emptyList()),
+            year = 2023,
             tiePoints = listOf(3, 2, 1),
             hasGiveaway = false,
             giveawayAmountUSD = 0,
-            deadline = tomorrow()
+            defaultLocalTimeZone = null,
+            deadline = testTime
         )
         assertNotNull(actual)
     }

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/TemplateServiceTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/TemplateServiceTest.kt
@@ -16,7 +16,7 @@ class TemplateServiceTest {
         val properties = Properties(
             title="",
             year = 2077,
-            goty = GotyQuestion("", "", emptyList()),
+            gotyQuestion = GotyQuestion("", "", emptyList()),
             tiePoints = listOf(9, 8, 7),
             deadline = deadline,
             hasGiveaway = true,
@@ -50,7 +50,7 @@ class TemplateServiceTest {
         val properties = Properties(
             title="",
             year = 2077,
-            goty = GotyQuestion("", "", emptyList()),
+            gotyQuestion = GotyQuestion("", "", emptyList()),
             tiePoints = listOf(9, 8, 7),
             deadline = deadline,
             hasGiveaway = true,
@@ -68,7 +68,7 @@ class TemplateServiceTest {
         val properties = Properties(
             title="",
             year = 2077,
-            goty = GotyQuestion("", "", emptyList()),
+            gotyQuestion = GotyQuestion("", "", emptyList()),
             tiePoints = listOf(9, 8, 7),
             deadline = deadline,
             hasGiveaway = true,
@@ -86,7 +86,7 @@ class TemplateServiceTest {
         val properties = Properties(
             title="",
             year = 2077,
-            goty = GotyQuestion("", "", emptyList()),
+            gotyQuestion = GotyQuestion("", "", emptyList()),
             tiePoints = listOf(9, 8, 7),
             deadline = deadline,
             hasGiveaway = true,
@@ -106,7 +106,7 @@ class TemplateServiceTest {
         val properties = Properties(
                 title="",
                 year = 2077,
-                goty = GotyQuestion("", "", emptyList()),
+                gotyQuestion = GotyQuestion("", "", emptyList()),
                 tiePoints = listOf(9, 8, 7),
                 deadline = deadline,
                 hasGiveaway = true,
@@ -125,7 +125,7 @@ class TemplateServiceTest {
         val properties = Properties(
                 title="",
                 year = 2077,
-                goty = GotyQuestion("", "", emptyList()),
+                gotyQuestion = GotyQuestion("", "", emptyList()),
                 tiePoints = listOf(9, 8, 7),
                 deadline = deadline,
                 hasGiveaway = true,

--- a/goty-server/src/test/kotlin/com/aleinin/goty/properties/TemplateServiceTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/properties/TemplateServiceTest.kt
@@ -1,0 +1,141 @@
+package com.aleinin.goty.properties
+
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import java.time.format.DateTimeFormatter
+
+class TemplateServiceTest {
+    private val deadline = ZonedDateTime.of(2078, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"))
+
+    private val templateService = TemplateService()
+
+    @Test
+    fun `should convert GotyQuestion to GotyQuestionResponse`() {
+        val properties = Properties(
+            title="",
+            year = 2077,
+            goty = GotyQuestion("", "", emptyList()),
+            tiePoints = listOf(9, 8, 7),
+            deadline = deadline,
+            hasGiveaway = true,
+            defaultLocalTimeZone = null,
+            giveawayAmountUSD = 0
+        )
+        val gotyQuestion = GotyQuestion(
+            title = "Games of the Year",
+            question = "What are your favorite game(s) of \${year}",
+            rules = listOf("Can vote for \${maxGames} games", "Can vote until \${deadline}")
+        )
+        val localTimeZone = ZoneId.of("America/Denver")
+        val expectedDate = properties.deadline.withZoneSameInstant(localTimeZone).format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a"))
+        val expected = GotyQuestionResponse(
+            title = ResolvedTemplate(template = gotyQuestion.title, text = gotyQuestion.title),
+            question = ResolvedTemplate(
+                template = gotyQuestion.question,
+                text = "What are your favorite game(s) of ${properties.year}"
+            ),
+            rules = listOf(
+                ResolvedTemplate(template = "Can vote for \${maxGames} games", text = "Can vote for ${properties.tiePoints.size} games"),
+                ResolvedTemplate(template = "Can vote until \${deadline}", text = "Can vote until $expectedDate")
+            )
+        )
+        val actual = templateService.toGotyQuestionResponse(gotyQuestion, properties, localTimeZone)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should convert ${year} to properties year`() {
+        val properties = Properties(
+            title="",
+            year = 2077,
+            goty = GotyQuestion("", "", emptyList()),
+            tiePoints = listOf(9, 8, 7),
+            deadline = deadline,
+            hasGiveaway = true,
+            defaultLocalTimeZone = null,
+            giveawayAmountUSD = 0
+        )
+        val template = "It is \${year}"
+        val expected = ResolvedTemplate(template = template, text = "It is ${properties.year}")
+        val actual = templateService.toResolvedTemplate(template, properties, null)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should convert ${maxGame} to properties tiePoints size`() {
+        val properties = Properties(
+            title="",
+            year = 2077,
+            goty = GotyQuestion("", "", emptyList()),
+            tiePoints = listOf(9, 8, 7),
+            deadline = deadline,
+            hasGiveaway = true,
+            defaultLocalTimeZone = null,
+            giveawayAmountUSD = 0
+        )
+        val template = "You can nominate up to \${maxGames} games"
+        val expected = ResolvedTemplate(template = template, text = "You can nominate up to ${properties.tiePoints.size} games")
+        val actual = templateService.toResolvedTemplate(template, properties, null)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should convert ${deadline} to properties deadline in localTimeZone`() {
+        val properties = Properties(
+            title="",
+            year = 2077,
+            goty = GotyQuestion("", "", emptyList()),
+            tiePoints = listOf(9, 8, 7),
+            deadline = deadline,
+            hasGiveaway = true,
+            defaultLocalTimeZone = null,
+            giveawayAmountUSD = 0
+        )
+        val localTimeZone = ZoneId.of("America/Chicago")
+        val template = "Deadline is at \${deadline}"
+        val localTime = properties.deadline.withZoneSameInstant(localTimeZone).format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a"))
+        val expected = ResolvedTemplate(template = template, text = "Deadline is at $localTime")
+        val actual = templateService.toResolvedTemplate(template, properties, localTimeZone)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should convert ${deadline} to properties deadline in defaultLocalTimeZone if localTimeZone null`() {
+        val properties = Properties(
+                title="",
+                year = 2077,
+                goty = GotyQuestion("", "", emptyList()),
+                tiePoints = listOf(9, 8, 7),
+                deadline = deadline,
+                hasGiveaway = true,
+                defaultLocalTimeZone = ZoneId.of("America/Los_Angeles"),
+                giveawayAmountUSD = 0
+        )
+        val template = "Deadline is at \${deadline}"
+        val localTime = properties.deadline.withZoneSameInstant(properties.defaultLocalTimeZone).format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a"))
+        val expected = ResolvedTemplate(template = template, text = "Deadline is at $localTime")
+        val actual = templateService.toResolvedTemplate(template, properties, null)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should convert ${deadline} to properties deadline in UTC if default and localTimeZone null`() {
+        val properties = Properties(
+                title="",
+                year = 2077,
+                goty = GotyQuestion("", "", emptyList()),
+                tiePoints = listOf(9, 8, 7),
+                deadline = deadline,
+                hasGiveaway = true,
+                defaultLocalTimeZone = null,
+                giveawayAmountUSD = 0
+        )
+        val template = "Deadline is at \${deadline}"
+        val localTime = properties.deadline.withZoneSameInstant(ZoneId.of("Etc/GMT")).format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a"))
+        val expected = ResolvedTemplate(template = template, text = "Deadline is at $localTime")
+        val actual = templateService.toResolvedTemplate(template, properties, null)
+        assertEquals(expected, actual)
+    }
+}

--- a/goty-server/src/test/kotlin/com/aleinin/goty/submission/SubmissionServiceTest.kt
+++ b/goty-server/src/test/kotlin/com/aleinin/goty/submission/SubmissionServiceTest.kt
@@ -44,7 +44,6 @@ class SubmissionServiceTest {
     private fun getExpectedTooManyGamesMessage(tiePoints: List<Int>) = "Too many games of the year. The maximum allowed is ${tiePoints.size}."
     private fun getExpectedOverrideRequiredMessage(deadline: ZonedDateTime) = "Submission deadline of $deadline has not been met. You must override to delete all submissions."
 
-
     private fun setupBeforeDeadline(): ZonedDateTime {
         whenever(propertiesService.getProperties()).thenReturn(properties)
         whenever(properties.deadline).thenReturn(testTime)

--- a/goty-server/src/test/resources/application.yml
+++ b/goty-server/src/test/resources/application.yml
@@ -4,7 +4,7 @@ goty:
     password: test
   default:
     title: Top Games of the Year $year
-    goty:
+    gotyQuestion:
       title: Games of the Year
       question: What are your favorite game(s) of ${year}?
       rules:

--- a/goty-server/src/test/resources/application.yml
+++ b/goty-server/src/test/resources/application.yml
@@ -3,10 +3,17 @@ goty:
     username: test
     password: test
   default:
-    gotyYear: 2077
+    title: Top Games of the Year $year
+    goty:
+      title: Games of the Year
+      question: What are your favorite game(s) of ${year}?
+      rules:
+        - Whatever you want, this is a test.
+    year: 2077
     deadline: 2077-01-01T00:00:00-05:00
     hasGiveaway: true
     giveawayAmountUSD: 25
+    defaultLocalTimeZone: Etc/GMT
     tiePoints:
       - 15
       - 13


### PR DESCRIPTION
## What changed?
* Added a string templating system: see adr
* Moved page title to backend properties
* Moved goty title, question, rules to backend properties
* Removed TMW from document titles
* Increased title font sizes
* Changed card titles to basic summaries "Most Anticipated" and moved the question below


## Why?
Ultimately this will support adding questions as code. In order for additional questions to be stored in backend properties, there needed to be a basic templating system for variables. This supports that and it was a big enough addition in its own that I wanted to piece it out. 